### PR TITLE
+change routes format: get host,location,staging as json

### DIFF
--- a/tools/consul/nginx_template_context.go
+++ b/tools/consul/nginx_template_context.go
@@ -68,9 +68,9 @@ func NginxTemplateContextCommand() cli.Command {
 						location = "/"
 					}
 
-					staging, ok := route["staging"]
+					stage, ok := route["stage"]
 					if !ok {
-						staging = "live"
+						stage = "live"
 					}
 
 					if _, ok := servers[route["host"]]; !ok {
@@ -82,8 +82,8 @@ func NginxTemplateContextCommand() cli.Command {
 						servers[route["host"]][location]["service"] = name // todo: backward compatibility for inn-ci-tools, remove after
 					}
 
-					if _, ok := servers[route["host"]][location][staging]; !ok {
-						servers[route["host"]][location][staging] = upstream
+					if _, ok := servers[route["host"]][location][stage]; !ok {
+						servers[route["host"]][location][stage] = upstream
 					}
 				}
 			}

--- a/tools/consul/route.go
+++ b/tools/consul/route.go
@@ -57,7 +57,7 @@ func RouteCommand() cli.Command {
 				return err
 			}
 
-			log.Println(color.GreenString("Updated routes for `%s`: %s", name, string(routes)))
+			log.Println(color.GreenString("Updated routes for `%s`: %s", name, routes))
 
 			return nil
 		},

--- a/tools/consul/route.go
+++ b/tools/consul/route.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -9,8 +8,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/hashicorp/consul/api"
 	"github.com/cenk/backoff"
-
-	"github.com/InnovaCo/serve/utils"
 )
 
 func RouteCommand() cli.Command {
@@ -19,9 +16,7 @@ func RouteCommand() cli.Command {
 		Usage: "Save app route to consul",
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "service"},
-			cli.StringFlag{Name: "host"},
-			cli.StringFlag{Name: "location", Value: "/"},
-			cli.StringFlag{Name: "route"},
+			cli.StringFlag{Name: "routes"},
 		},
 		Action: func(c *cli.Context) error {
 			consul, _ := api.NewClient(api.DefaultConfig())
@@ -48,19 +43,8 @@ func RouteCommand() cli.Command {
 				return err
 			}
 
-			routeFlags := make(map[string]string, 0)
-			if c.IsSet("route") {
-				if err := json.Unmarshal([]byte(c.String("route")), &routeFlags); err != nil {
-					return err
-				}
-			}
+			routes := c.String("routes")
 
-			route := utils.MergeMaps(map[string]string{
-				"host":     c.String("host"),
-				"location": c.String("location"),
-			}, routeFlags)
-
-			routesJson, err := json.MarshalIndent([]map[string]string{route}, "", "  ")
 			if err != nil {
 				return err
 			}
@@ -68,12 +52,12 @@ func RouteCommand() cli.Command {
 			// write routes to consul kv
 			if _, err := consul.KV().Put(&api.KVPair{
 				Key:   fmt.Sprintf("services/routes/%s", name),
-				Value: routesJson,
+				Value: []byte(routes),
 			}, nil); err != nil {
 				return err
 			}
 
-			log.Println(color.GreenString("Updated routes for `%s`: %s", name, string(routesJson)))
+			log.Println(color.GreenString("Updated routes for `%s`: %s", name, string(routes)))
 
 			return nil
 		},


### PR DESCRIPTION
@kulikov @mhanygin ,

меняем формат routes.

Можно вызывать из ci-tools:
```
serve-tools consul route --service "some_package" --routes '[{"host": "host1", "location": "location1", "staging": "stage"}, {...}]'
```