### PR TITLE
Feature debian plugins

### DIFF
--- a/plugins/deploy.marathon.go
+++ b/plugins/deploy.marathon.go
@@ -22,7 +22,7 @@ func init() {
 type DeployMarathon struct{}
 
 func (p DeployMarathon) Run(data manifest.Manifest) error {
-	marathonApi, err := MarathonClient(data.GetString("marathon_host"))
+	marathonApi, err := MarathonClient(data.GetString("marathon-host"))
 	if err != nil {
 		return err
 	}

--- a/plugins/release.go
+++ b/plugins/release.go
@@ -22,8 +22,7 @@ func init() {
 type Release struct{}
 
 func (p Release) Run(data manifest.Manifest) error {
-	log.Println(color.BlueString("data = %s", data))
-	consulApi, err := ConsulClient(data.GetString("consul_host"))
+	consulApi, err := ConsulClient(data.GetString("consul-host"))
 	if err != nil {
 		return err
 	}

--- a/serve.go
+++ b/serve.go
@@ -42,7 +42,7 @@ func main() {
 		log.Println(color.GreenString("%v:\n", pair.PluginName), pair.Data)
 
 		if !*dryRun {
-			if err := pair.Plugin.Run(pair.Data, vars); err != nil {
+			if err := pair.Plugin.Run(pair.Data); err != nil {
 				fmt.Println("")
 				log.Fatalln(color.RedString("Error on run plugin `%s`: %v", pair.PluginName, err))
 			}


### PR DESCRIPTION
@mhanygin @kulikov ,
- +плагин _build.debian_. Там эскcпортируются переменные, полученные из манифеста (глобального и манифеста компонента). Далее вызывается debian-build.sh. В debian-build.sh необходимо будет убрать вызов ci-tools парсера manifest'a.
- +плагин _deploy.debian_. Подготавливает данные для вызова deploy.sh
- явно передаю vars во все плагины. Как альтернативный вариант - в manifest.go можно всегда добавлять vars (после мержа результата парсинга дерева).
- Разделяем переменные манифеста: те, которые существуют для всех компонентов, находятся в глобальном манифесте. Это:

```
  debian:
    name-version: "{{ info.name }}-v{{ info.build-version }}"
    version: "{{info.version}}"
    category: "{{info.category}}"
    name: "{{info.name}}"
    section: "{{info.category}}"
    maintainer-email: "bamboo@inn.ru"
    maintainer-name: "Continuous Integration"
    description: "{{info.description}}"
    init: "debian-way"
```

Остальные должны определяться в каждом компоненте (т.к. являются специфичными для каждого компонента):

```
  - debian:
      install-root: "/local/innova/www-versions"
      daemon-args: "echo Start"
      service-owner: "innova"
      daemon-user: "innova"
      daemon: "no"
      daemon-port:
      make-pidfile: "false"
```
